### PR TITLE
Add python3 to shebang

### DIFF
--- a/config-files/UM/um_env_to_yaml.py
+++ b/config-files/UM/um_env_to_yaml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2024 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
This pull request specifies python3 in the `um_env_to_yaml.py` script, as I got a warning when trying to run on gadi without it.